### PR TITLE
Epic games structs POC

### DIFF
--- a/AmongUsCapture/Memory/GameMemReader.cs
+++ b/AmongUsCapture/Memory/GameMemReader.cs
@@ -259,7 +259,8 @@ namespace AmongUsCapture
 
                         for (var i = 0; i < playerCount; i++)
                         {
-                            var pi = ProcessMemory.getInstance().Read<PlayerInfo>(playerAddrPtr, 0, 0);
+                            // TODO: Actually implement this. Note the explicit types, also passed to ProcessMemory#Read()
+                            PlayerInfo pi = isSteam ? ProcessMemory.getInstance().Read<SteamPlayerInfo>(playerAddrPtr, 0, 0) : ProcessMemory.getInstance().Read<EpicPlayerInfo>(playerAddrPtr, 0, 0);
                             playerAddrPtr += 4;
 
                             if (pi.PlayerId == exiledPlayerId)
@@ -273,7 +274,7 @@ namespace AmongUsCapture
                                 });
 
                             // skip invalid, dead and exiled players
-                            if (pi.PlayerName == 0 || pi.PlayerId == exiledPlayerId || pi.IsDead == 1 ||
+                            if (pi.PlayerName == IntPtr.Zero || pi.PlayerId == exiledPlayerId || pi.IsDead == 1 ||
                                 pi.Disconnected == 1) continue;
 
                             if (pi.IsImpostor == 1)
@@ -368,9 +369,10 @@ namespace AmongUsCapture
 
                     for (var i = 0; i < playerCount; i++)
                     {
-                        var pi = ProcessMemory.getInstance().Read<PlayerInfo>(playerAddrPtr, 0, 0);
+                        // TODO: Actually implement this. Note the explicit types, also passed to ProcessMemory#Read()
+                        PlayerInfo pi = isSteam ? ProcessMemory.getInstance().Read<SteamPlayerInfo>(playerAddrPtr, 0, 0) : ProcessMemory.getInstance().Read<EpicPlayerInfo>(playerAddrPtr, 0, 0);
                         playerAddrPtr += 4;
-                        if (pi.PlayerName == 0) continue;
+                        if (pi.PlayerName == IntPtr.Zero) continue;
                         var playerName = pi.GetPlayerName();
                         if (playerName.Length == 0) continue;
 

--- a/AmongUsCapture/Memory/Structs/EpicPlayerInfo.cs
+++ b/AmongUsCapture/Memory/Structs/EpicPlayerInfo.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AmongUsCapture.Memory.Structs
+{
+    [System.Runtime.InteropServices.StructLayout(LayoutKind.Explicit)]
+    public struct EpicPlayerInfo : PlayerInfo
+    {
+        [System.Runtime.InteropServices.FieldOffset(16)] public byte PlayerId;
+        [System.Runtime.InteropServices.FieldOffset(24)] public ulong PlayerName;
+        [System.Runtime.InteropServices.FieldOffset(32)] public byte ColorId;
+        [System.Runtime.InteropServices.FieldOffset(36)] public uint HatId;
+        [System.Runtime.InteropServices.FieldOffset(40)] public uint PetId;
+        [System.Runtime.InteropServices.FieldOffset(44)] public uint SkinId;
+        [System.Runtime.InteropServices.FieldOffset(48)] public byte Disconnected;
+        [System.Runtime.InteropServices.FieldOffset(56)] public IntPtr Tasks;
+        [System.Runtime.InteropServices.FieldOffset(64)] public byte IsImpostor;
+        [System.Runtime.InteropServices.FieldOffset(65)] public byte IsDead;
+        [System.Runtime.InteropServices.FieldOffset(72)] public IntPtr _object;
+
+        byte PlayerInfo.PlayerId => PlayerId;
+
+        IntPtr PlayerInfo.PlayerName => (IntPtr)PlayerName;
+
+        byte PlayerInfo.ColorId => ColorId;
+
+        uint PlayerInfo.HatId => HatId;
+
+        uint PlayerInfo.PetId => PetId;
+
+        uint PlayerInfo.SkinId => SkinId;
+
+        byte PlayerInfo.Disconnected => Disconnected;
+
+        IntPtr PlayerInfo.Tasks => Tasks;
+
+        byte PlayerInfo.IsImpostor => IsImpostor;
+
+        byte PlayerInfo.IsDead => IsDead;
+
+        IntPtr PlayerInfo._object => _object;
+    }
+}

--- a/AmongUsCapture/Memory/Structs/PlayerInfo.cs
+++ b/AmongUsCapture/Memory/Structs/PlayerInfo.cs
@@ -1,22 +1,24 @@
 ﻿using System;
-using System.Runtime.InteropServices;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 
-namespace AmongUsCapture
+namespace AmongUsCapture.Memory.Structs
 {
-    [System.Runtime.InteropServices.StructLayout(LayoutKind.Explicit)]
-    public struct PlayerInfo
+    public interface PlayerInfo
     {
-        [System.Runtime.InteropServices.FieldOffset(8)] public byte PlayerId;
-        [System.Runtime.InteropServices.FieldOffset(12)] public uint PlayerName;
-        [System.Runtime.InteropServices.FieldOffset(16)] public byte ColorId;
-        [System.Runtime.InteropServices.FieldOffset(20)] public uint HatId;
-        [System.Runtime.InteropServices.FieldOffset(24)] public uint PetId;
-        [System.Runtime.InteropServices.FieldOffset(28)] public uint SkinId;
-        [System.Runtime.InteropServices.FieldOffset(32)] public byte Disconnected;
-        [System.Runtime.InteropServices.FieldOffset(36)] public IntPtr Tasks;
-        [System.Runtime.InteropServices.FieldOffset(40)] public byte IsImpostor;
-        [System.Runtime.InteropServices.FieldOffset(41)] public byte IsDead;
-        [System.Runtime.InteropServices.FieldOffset(44)] public IntPtr _object;
+        public abstract byte PlayerId { get; }
+        public abstract IntPtr PlayerName { get; }
+        public abstract byte ColorId { get; }
+        public abstract uint HatId { get;  }
+        public abstract uint PetId { get; }
+        public abstract uint SkinId { get; }
+        public abstract byte Disconnected { get; }
+        public abstract IntPtr Tasks { get; }
+        public abstract byte IsImpostor { get; }
+        public abstract byte IsDead { get; }
+        public abstract IntPtr _object { get; }
 
         public bool GetIsDead()
         {

--- a/AmongUsCapture/Memory/Structs/SteamPlayerInfo.cs
+++ b/AmongUsCapture/Memory/Structs/SteamPlayerInfo.cs
@@ -1,0 +1,44 @@
+﻿using AmongUsCapture.Memory.Structs;
+using System;
+using System.Runtime.InteropServices;
+
+namespace AmongUsCapture
+{
+    [System.Runtime.InteropServices.StructLayout(LayoutKind.Explicit)]
+    public struct SteamPlayerInfo : PlayerInfo
+    {
+        [System.Runtime.InteropServices.FieldOffset(8)] public byte PlayerId;
+        [System.Runtime.InteropServices.FieldOffset(12)] public uint PlayerName;
+        [System.Runtime.InteropServices.FieldOffset(16)] public byte ColorId;
+        [System.Runtime.InteropServices.FieldOffset(20)] public uint HatId;
+        [System.Runtime.InteropServices.FieldOffset(24)] public uint PetId;
+        [System.Runtime.InteropServices.FieldOffset(28)] public uint SkinId;
+        [System.Runtime.InteropServices.FieldOffset(32)] public byte Disconnected;
+        [System.Runtime.InteropServices.FieldOffset(36)] public IntPtr Tasks;
+        [System.Runtime.InteropServices.FieldOffset(40)] public byte IsImpostor;
+        [System.Runtime.InteropServices.FieldOffset(41)] public byte IsDead;
+        [System.Runtime.InteropServices.FieldOffset(44)] public IntPtr _object;
+
+        byte PlayerInfo.PlayerId => PlayerId;
+
+        IntPtr PlayerInfo.PlayerName => (IntPtr)PlayerName;
+
+        byte PlayerInfo.ColorId => ColorId;
+
+        uint PlayerInfo.HatId => HatId;
+
+        uint PlayerInfo.PetId => PetId;
+
+        uint PlayerInfo.SkinId => SkinId;
+
+        byte PlayerInfo.Disconnected => Disconnected;
+
+        IntPtr PlayerInfo.Tasks => Tasks;
+
+        byte PlayerInfo.IsImpostor => IsImpostor;
+
+        byte PlayerInfo.IsDead => IsDead;
+
+        IntPtr PlayerInfo._object => _object;
+    }
+}


### PR DESCRIPTION
Implements a common interface for the PlayerInfo structs to make both steam and epic support possible. Just an example, so not merge-ready for master -- the `isSteam` boolean is just a placeholder, but it should be implemented to switch between the steam/epic games structs.