### PR TITLE
Fix a problem with GameCode reading on v2021.4.12s

### DIFF
--- a/Offsets.json
+++ b/Offsets.json
@@ -506,7 +506,7 @@
     "WinningPlayersPtrOffsets": [0x28736EC, 92, 12],
     "WinningPlayersOffsets": [8],
     "WinningPlayerCountOffsets": [12],
-    "GameCodeOffsets": [0x2821D18, 92, 0, 32, 40],
+    "GameCodeOffsets": [0x2821D18, 92, 0, 0x20, 0x80],
     "PlayRegionOffsets": [0x2822270, 92, 0, 16, 8, 8],
     "PlayMapOffsets": [0x28801B8, 92, 4, 16],
     "StringOffsets": [8, 12],


### PR DESCRIPTION
On v2021.4.12s update, the structure of the class containing GameCode has been changed.
So I fixed offsets.