### PR TITLE
Add support for v2021.4.14m

### DIFF
--- a/AmongUsCapture/Memory/Structs/EpicPlayerInfo.cs
+++ b/AmongUsCapture/Memory/Structs/EpicPlayerInfo.cs
@@ -12,11 +12,11 @@ namespace AmongUsCapture.Memory.Structs
     {
         [System.Runtime.InteropServices.FieldOffset(16)] public byte PlayerId;
         [System.Runtime.InteropServices.FieldOffset(24)] public long PlayerName;
-        [System.Runtime.InteropServices.FieldOffset(33)] public byte ColorId;
-        [System.Runtime.InteropServices.FieldOffset(36)] public uint HatId;
-        [System.Runtime.InteropServices.FieldOffset(40)] public uint PetId;
-        [System.Runtime.InteropServices.FieldOffset(44)] public uint SkinId;
-        [System.Runtime.InteropServices.FieldOffset(48)] public byte Disconnected;
+        [System.Runtime.InteropServices.FieldOffset(36)] public byte ColorId;
+        [System.Runtime.InteropServices.FieldOffset(40)] public uint HatId;
+        [System.Runtime.InteropServices.FieldOffset(44)] public uint PetId;
+        [System.Runtime.InteropServices.FieldOffset(48)] public uint SkinId;
+        [System.Runtime.InteropServices.FieldOffset(52)] public byte Disconnected;
         [System.Runtime.InteropServices.FieldOffset(56)] public IntPtr Tasks;
         [System.Runtime.InteropServices.FieldOffset(64)] public byte IsImpostor;
         [System.Runtime.InteropServices.FieldOffset(65)] public byte IsDead;

--- a/Offsets.json
+++ b/Offsets.json
@@ -607,5 +607,36 @@
     "AddPlayerPtr": 4,
     "PlayerListPtr": 16
   },
+  "6C6E2914387B6D8594759F4864D976DF5625AF7F738F72C8525C4BF9E836ADE3": {
+    "Description": "v2021.4.14m",
+    "AmongUsClientOffset": 0x2FCFD78,
+    "GameDataOffset": 0x3002D38,
+    "MeetingHudOffset": 0x2FBD680,
+    "GameStartManagerOffset": 0x2F692F8,
+    "HudManagerOffset": 0x2F694E8,
+    "ServerManagerOffset": 0x2F69CE8,
+    "TempDataOffset": 0x2FBB7A8,
+    "GameOptionsOffset": 0x2FD2C30,
+
+    "MeetingHudPtr": [0x2FBD680, 0xB8, 0x0],
+    "MeetingHudCachePtrOffsets": [0x10],
+    "MeetingHudStateOffsets": [0xC0],
+    "GameStateOffsets": [0x2FCFD78, 0xB8, 0x0, 0xC4],
+    "AllPlayerPtrOffsets": [0x3002D38, 0xB8, 0x0, 0x30],
+    "AllPlayersOffsets": [0x10],
+    "PlayerCountOffsets": [0x18],
+    "ExiledPlayerIdOffsets": [0x2FBD680, 0xB8, 0x0, 0xE0, 0x10],
+    "RawGameOverReasonOffsets": [0x2FBB7A8, 0xB8, 0x4],
+    "WinningPlayersPtrOffsets": [0x2FBB7A8, 0xB8, 0x10],
+    "WinningPlayersOffsets": [0x10],
+    "WinningPlayerCountOffsets": [0x18],
+    "GameCodeOffsets": [0x2F692F8, 0xB8, 0x0, 0x40, 0xD8],
+    "PlayRegionOffsets": [0x2F69CE8, 0xB8, 0x0, 0x20, 0x10],
+    "PlayMapOffsets": [0x2FD2C30, 0xB8, 0x8, 0x18],
+    "StringOffsets": [0x10, 0x14],
+    "isEpic": true,
+    "AddPlayerPtr": 0x8,
+    "PlayerListPtr": 0x20
+  }
 }
 


### PR DESCRIPTION
Add support for v2021.4.14m.

This updates `Offsets.json` and hard-coded offsets in `EpicPlayerInfo.cs`, so requires the release of a new version.