### PR TITLE
fix: use explicit ReadInt per platform

### DIFF
--- a/AmongUsCapture/Memory/Structs/PlayerInfo.cs
+++ b/AmongUsCapture/Memory/Structs/PlayerInfo.cs
@@ -30,7 +30,7 @@ namespace AmongUsCapture
                 fixed (byte* ptr = buffer) {
                     var buffptr = (IntPtr) ptr;
                     PlayerId = Marshal.ReadByte(buffptr, pOf.PlayerIDOffset);
-                    var NamePTR = Marshal.ReadIntPtr(buffptr, pOf.PlayerNameOffset);
+                    var NamePTR = MemInstance.is64Bit ? (IntPtr) Marshal.ReadInt64(buffptr, pOf.PlayerNameOffset) : (IntPtr) Marshal.ReadInt32(buffptr, pOf.PlayerNameOffset);
                     PlayerName = NamePTR == IntPtr.Zero ? "" : MemInstance.ReadString(NamePTR, CurrentOffsets.StringOffsets[0], CurrentOffsets.StringOffsets[1]);
                     ColorId = (PlayerColor)(uint)Marshal.ReadInt32(buffptr, pOf.ColorIDOffset);
                     HatId = (uint) Marshal.ReadInt32(buffptr, pOf.HatIDOffset);

--- a/AmongUsCapture/Memory/Structs/WinningPlayerData.cs
+++ b/AmongUsCapture/Memory/Structs/WinningPlayerData.cs
@@ -35,7 +35,7 @@ namespace AmongUsCapture.Memory.Structs
 		        WinningPlayerDataStructOffsets pOf = CurrentOffsets.WinningPlayerDataStructOffsets;
 		        fixed (byte* ptr = buffer) {
 			        var buffptr = (IntPtr) ptr;
-			        var NamePTR = Marshal.ReadIntPtr(buffptr, pOf.NameOffset);
+			        var NamePTR = MemInstance.is64Bit ? (IntPtr) Marshal.ReadInt64(buffptr, pOf.NameOffset) : (IntPtr) Marshal.ReadInt32(buffptr, pOf.NameOffset);
 			        Name = NamePTR == IntPtr.Zero ? "" : MemInstance.ReadString(NamePTR, CurrentOffsets.StringOffsets[0], CurrentOffsets.StringOffsets[1]);
 			        ColorId = (int)Marshal.ReadInt32(buffptr, pOf.ColorOffset);
 			        HatId = (uint) Marshal.ReadInt32(buffptr, pOf.HatOffset);


### PR DESCRIPTION
Fix an issue that the name of the winner could not be read from memory correctly when there was only one winner on 32 bit platform like Steam.