### PR TITLE
fix: ignore new player with invalid color id (#267)

### DIFF
--- a/AmongUsCapture/Memory/GameMemReader.cs
+++ b/AmongUsCapture/Memory/GameMemReader.cs
@@ -105,7 +105,7 @@ namespace AmongUsCapture {
             for (var i = 0; i < playerCount; i++) {
                 var pi = new PlayerInfo(playerAddrPtr, memInstance, CurrentOffsets);
                 //var pi = CurrentOffsets.isEpic ? (PlayerInfo) memInstance.Read<EpicPlayerInfo>(playerAddrPtr, 0, 0) : memInstance.Read<SteamPlayerInfo>(playerAddrPtr, 0, 0);
-                if(pi.GetPlayerName() is null || pi.GetPlayerName() == "") continue;
+                if(pi.GetPlayerName() is null || pi.GetPlayerName() == "" || !Enum.IsDefined(typeof(PlayerColor), pi.GetPlayerColor())) continue;
                 playerAddrPtr += CurrentOffsets.AddPlayerPtr;
                 Players.Add(pi);
             }


### PR DESCRIPTION
Closes #267

Tested in simillar way as described in #267, the issue has been solved.

```
06:47:32.6093|INFO|AmongUsCapture.PlayerInfo|RawPlayerInfo: "Rounddust", Black, 0, 0, false
06:47:32.6312|INFO|AmongUsCapture.PlayerInfo|RawPlayerInfo: "Rounddust", Black, 0, 0, false
06:47:32.6422|INFO|AmongUsCapture.PlayerInfo|RawPlayerInfo: "Rounddust", Black, 0, 0, false
06:47:32.6422|INFO|AmongUsCapture.PlayerInfo|RawPlayerInfo: "", Unknown, 0, 0, false    👈👈👈👈👈　Player instance created
06:47:32.6422|INFO|AmongUsCapture.PlayerInfo|RawPlayerInfo: "Rounddust", Black, 0, 0, false
06:47:32.6422|INFO|AmongUsCapture.PlayerInfo|RawPlayerInfo: "", Unknown, 0, 0, false
...
06:47:32.9210|INFO|AmongUsCapture.PlayerInfo|RawPlayerInfo: "Rounddust", Black, 0, 0, false
06:47:32.9210|INFO|AmongUsCapture.PlayerInfo|RawPlayerInfo: "", Unknown, 0, 0, false
06:47:32.9210|INFO|AmongUsCapture.PlayerInfo|RawPlayerInfo: "Rounddust", Black, 0, 0, false
06:47:32.9210|INFO|AmongUsCapture.PlayerInfo|RawPlayerInfo: "Twokite", Unknown, 0, 0, false    👈👈👈👈👈　Only name is updated and its color is still -1, no event fired at this time and capture keeps working
06:47:32.9438|INFO|AmongUsCapture.PlayerInfo|RawPlayerInfo: "Rounddust", Black, 0, 0, false
06:47:32.9438|INFO|AmongUsCapture.PlayerInfo|RawPlayerInfo: "Twokite", Red, 0, 0, false    👈👈👈👈👈　Color has been updated
06:47:32.9438|DEBUG|AUCapture_WPF.MainWindow|{"Action":"Joined", "Name":"Twokite", "IsDead":false, "Disconnected":false, "Color":"Red"}    👈👈👈👈👈　"Joined" event fired with correct data
```

@CarbonNeuron 
Could you review this and add new tag like `4.2.1` if this seems ok for you? Thanks.