### PR TITLE
Fixed a problem where display the room code was "??????"

### DIFF
--- a/AmongUsCapture/Memory/GameMemReader.cs
+++ b/AmongUsCapture/Memory/GameMemReader.cs
@@ -1,9 +1,10 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using AmongUsCapture.Memory.Structs;
 using AUOffsetManager;
@@ -350,7 +351,7 @@ namespace AmongUsCapture {
 
                     if (state != oldState && state == GameState.LOBBY || shouldReadLobby) {
                         var gameCode = GetGameCode(ProcessMemory.getInstance());
-                        if (!string.IsNullOrEmpty(gameCode)) {
+                        if (!string.IsNullOrEmpty(gameCode) && Regex.IsMatch(gameCode, "^[A-Z]{4}$|^[A-Z]{6}$|^\\*{6}$")) {
                             latestLobbyEventArgs = new LobbyEventArgs {
                                 LobbyCode = gameCode,
                                 Region = GetPlayRegion(ProcessMemory.getInstance()),


### PR DESCRIPTION
## Overview
Fixed a problem that the room code could not be retrieved properly and displayed "??????" depending on the timing of returning to the lobby.

## Fix
- Add filtering by Regular Expression
  - Exact match to 4 or 6 letters of the alphabet
  - Exact match at ****** ※1

※1  If possible, I would like to correct the offset so that I can get the GameCode correctly even in StreamerMode, but I don't know which tool to use to check the Offset, so this is a stopgap measure.