### PR TITLE
Add "No end judgment by exile" Option

### DIFF
--- a/AUCapture-WPF/AppSettings.cs
+++ b/AUCapture-WPF/AppSettings.cs
@@ -14,6 +14,9 @@ namespace AUCapture_WPF
         [Option(DefaultValue = "")]
         string language { get; set; }
 
+        [Option(DefaultValue = false)]
+        bool NoEndJudgmentByExile { get; set; }
+
         [Option(DefaultValue = true)]
         bool startupMemes { get; set; }
 

--- a/AUCapture-WPF/MainWindow.xaml
+++ b/AUCapture-WPF/MainWindow.xaml
@@ -209,6 +209,11 @@
                                                 OffContent="{l:Static properties:Resources.OffText}"
                                                 OnContent="{l:Static properties:Resources.OnText}" />
                                             <mah:ToggleSwitch
+                                                Header="{l:Static properties:Resources.SettingsGeneralTabNoEndJudgmentByExile}"
+                                                IsOn="{Binding Settings.NoEndJudgmentByExile, Mode=TwoWay}"
+                                                OffContent="{l:Static properties:Resources.OffText}"
+                                                OnContent="{l:Static properties:Resources.OnText}" />
+                                            <mah:ToggleSwitch
                                                 Header="{l:Static properties:Resources.SettingsGeneralTabStartupMemes}"
                                                 IsOn="{Binding Settings.startupMemes, Mode=TwoWay}"
                                                 OffContent="{l:Static properties:Resources.OffText}"

--- a/AUCapture-WPF/Properties/Resources.Designer.cs
+++ b/AUCapture-WPF/Properties/Resources.Designer.cs
@@ -421,6 +421,15 @@ namespace AUCapture_WPF.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No end judgment by exile.
+        /// </summary>
+        public static string SettingsGeneralTabNoEndJudgmentByExile {
+            get {
+                return ResourceManager.GetString("SettingsGeneralTabNoEndJudgmentByExile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Always on top.
         /// </summary>
         public static string SettingsGeneralTabAlwaysOnTop {

--- a/AUCapture-WPF/Properties/Resources.ja.resx
+++ b/AUCapture-WPF/Properties/Resources.ja.resx
@@ -114,6 +114,9 @@
   <data name="SettingsGeneralTabAlwaysCopyGameCode" xml:space="preserve">
     <value>常にゲームコードをコピー</value>
   </data>
+  <data name="SettingsGeneralTabNoEndJudgmentByExile" xml:space="preserve">
+    <value>追放で終了判定を行わない</value>
+  </data>
   <data name="SettingsGeneralTabAlwaysOnTop" xml:space="preserve">
     <value>常に最前面に表示</value>
   </data>

--- a/AUCapture-WPF/Properties/Resources.resx
+++ b/AUCapture-WPF/Properties/Resources.resx
@@ -122,6 +122,9 @@
   <data name="SettingsGeneralTabAlwaysCopyGameCode" xml:space="preserve">
     <value>Always copy game code</value>
   </data>
+  <data name="SettingsGeneralTabNoEndJudgmentByExile" xml:space="preserve">
+    <value>No end judgment by exile</value>
+  </data>
   <data name="SettingsGeneralTabFocusOnConnect" xml:space="preserve">
     <value>Focus window on connect</value>
   </data>

--- a/AUCapture-WPF/UserDataContext.cs
+++ b/AUCapture-WPF/UserDataContext.cs
@@ -410,6 +410,7 @@ namespace AUCapture_WPF
 
         private void SettingsOnPropertyChanged(object sender, PropertyChangedEventArgs e)
         {
+            AmongUsCapture.Settings.PersistentSettings.noEndJudgmentByExile = Settings.NoEndJudgmentByExile;
             if (e.PropertyName == nameof(Settings.debug))
             {
                 AmongUsCapture.Settings.PersistentSettings.debugConsole = Settings.debug;

--- a/AmongUsCapture/Memory/GameMemReader.cs
+++ b/AmongUsCapture/Memory/GameMemReader.cs
@@ -327,7 +327,7 @@ namespace AmongUsCapture {
                             impostorCount = GetPlayers(ProcessMemory.getInstance()).Count(x => x.GetIsImposter() && x.PlayerName != "" && x.PlayerId != exiledPlayer.PlayerId && !x.GetIsDead() && !x.GetIsDisconnected());
                             innocentCount = GetPlayers(ProcessMemory.getInstance()).Count(x => !x.GetIsImposter() && x.PlayerName != "" && x.PlayerId != exiledPlayer.PlayerId && !x.GetIsDead() && !x.GetIsDisconnected());
 
-                            if (impostorCount == 0 || impostorCount >= innocentCount) {
+                            if ((impostorCount == 0 || impostorCount >= innocentCount) && !Settings.PersistentSettings.noEndJudgmentByExile) {
                                 exileCausesEnd = true;
                                 state = GameState.LOBBY;
                             }

--- a/AmongUsCapture/Settings.cs
+++ b/AmongUsCapture/Settings.cs
@@ -45,6 +45,9 @@ namespace AmongUsCapture
         [Option(Alias = "DebugConsole", DefaultValue = false)]
         bool debugConsole { get; set; }
 
+        [Option(Alias = "NoEndJudgmentByExile", DefaultValue = false)]
+        bool noEndJudgmentByExile { get; set; }
+
         [Option(Alias = "IndexURL", DefaultValue = "https://raw.githubusercontent.com/automuteus/amonguscapture/master/Offsets.json")]
         string IndexURL { get; set; }
         


### PR DESCRIPTION
## Overview
Added "No end judgment by exile" option to allow some mods to continue the game even if the internal impostor is wiped out.
This solves the problem of the mute being unmuted by a lobby decision.