### PR TITLE
fix: replace deprecated args for goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v2.5.0
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
closes #406 
https://goreleaser.com/deprecations/#-rm-dist