### PR TITLE
fix: bump versions of actions in gha

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -11,16 +11,17 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v2.3.4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: "Get Previous tag"
+      - name: Get previous tag
         id: previoustag
-        uses: "WyriHaximus/github-action-get-previous-tag@master"
+        uses: WyriHaximus/github-action-get-previous-tag@v1
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1.8.0
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 5.0.100
 
@@ -40,7 +41,7 @@ jobs:
           7z a AmongUsCapture-Beta.zip ..\AmongUsCapture-Beta.exe -mx=9
       
       - name: AmongUsCapture-beta
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: AmongUsCapture-beta
           path: AmongUsCapture-Beta.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,38 +1,34 @@
-name: goreleaser
+name: Production releases
 
 on:
   push:
     tags:
       - "*"
 
+permissions:
+  contents: write
+
 jobs:
-  goreleaser:
+  release:
     runs-on: windows-latest
+
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Set up Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.15
-
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1.8.0
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 5.0.100
 
-      - name: "Get Previous tag"
-        id: previoustag
-        uses: "WyriHaximus/github-action-get-previous-tag@master"
-
       - name: Install dependencies
         run: dotnet restore "AUCapture-WPF\AUCapture-WPF.csproj"
+
       - name: Publish
         run: |
-          dotnet publish "AUCapture-WPF\AUCapture-WPF.csproj" -p:PublishProfile=PubProfile -p:AssemblyVersion=${{ steps.previoustag.outputs.tag }}.0
+          dotnet publish "AUCapture-WPF\AUCapture-WPF.csproj" -p:PublishProfile=PubProfile -p:AssemblyVersion=${{ github.ref_name }}.0
 
       - name: Relocate
         run: |
@@ -58,42 +54,8 @@ jobs:
         run: |
           echo "${{ steps.sign.outputs.encrypted-text }}" > ../AmongUsCapture.zip.sha256.pgp
 
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1.1.4
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          draft: false
-          prerelease: false
-
-      - name: Upload capture zip
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ..\AmongUsCapture.zip
-          asset_name: AmongUsCapture.zip
-          asset_content_type: application/zip
-
-      - name: Upload capture zip signature
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ..\AmongUsCapture.zip.sha256.pgp
-          asset_name: AmongUsCapture.zip.sha256.pgp
-          asset_content_type: text/plain
-
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2.5.0
-        with:
-          version: latest
-          args: release --clean
+      - name: Create release and upload assets
+        run: |
+          gh release create "${{ github.ref_name }}" --generate-notes ..\AmongUsCapture.zip ..\AmongUsCapture.zip.sha256.pgp
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Changes:

- Bump versions of actions in the pipelines
- Use `gh` command instead of actions to create release and upload assets
- Generate release notes automatically

Demos:

- https://github.com/kurokobo/amonguscapture/actions/runs/14269394244
- https://github.com/kurokobo/amonguscapture/actions/runs/14269397358

Closes #414 